### PR TITLE
fix get_transactions bug

### DIFF
--- a/src/ICRC1/lib.mo
+++ b/src/ICRC1/lib.mo
@@ -349,7 +349,7 @@ module {
             first_index := Nat.max(req.start, archive.stored_txs);
             let tx_start_index = (first_index - archive.stored_txs) : Nat;
 
-            txs_in_canister:= SB.slice(transactions, tx_start_index, req.length);
+            txs_in_canister:= SB.slice(transactions, tx_start_index, tx_start_index + req.length);
         };
 
         let archived_range = if (req.start < archive.stored_txs) {


### PR DESCRIPTION
If It has  3 transactions,  call get_transactions fail with Natural subtraction underflow.
you can test it if set a length less than start (by search inside transactions). 

```
// dfx call
call get_transactions '(record{start=2 : nat; length=1 : nat})'

```
the bug cause by this line. 
https://github.com/NatLabs/icrc1/blob/2ede9a69a6d9d15802d44dafb5403e767269e27b/src/ICRC1/lib.mo#L352

function SB.sclice accept argument (buffer, start, end)
https://github.com/NatLabs/icrc1/blob/2ede9a69a6d9d15802d44dafb5403e767269e27b/src/ICRC1/Utils.mo#L261

but the code call it , SB.slice(transactions, tx_start_index,  req.length).

it should fix  to
```

SB.slice(transactions, tx_start_index,  tx_start_index + req.length).

```
